### PR TITLE
Edit java stream for printing tasklist

### DIFF
--- a/data/CarlyList.txt
+++ b/data/CarlyList.txt
@@ -1,9 +1,7 @@
-T | 0 | read
+T | 0 | nqelg
 
-T | 0 | play
+D | 0 | sge | Sep 09 1990
 
-D | 1 | gqrg | Sep 09 1990
+E | 0 | adgnsg | 214 to bfnl
 
-D | 1 | gqrg | Sep 09 1990
-
-E | 0 | sdgnsg | g to g
+T | 1 | 24

--- a/src/main/java/carly/utils/TaskList.java
+++ b/src/main/java/carly/utils/TaskList.java
@@ -202,7 +202,7 @@ public class TaskList {
         return ONE_INDENT + "Now you have " + this.getSize() + " tasks in the list.";
     }
 
-    /** Prints list for Command FIND. */
+    /** Prints list for Command FIND using java streams. */
     public String printTaskList(String msg) {
         StringBuilder sb = new StringBuilder();
 
@@ -214,8 +214,7 @@ public class TaskList {
                     .forEach(i -> sb.append(String.format("%d.%s\n", i + 1, this.get(i).toString())));
         }
 
-        sb.append(this.taskListSize());
-        return sb.toString();
+        return sb.append(this.taskListSize()).toString();
     }
 
     /** Prints list for Command LIST. */

--- a/src/main/java/toComplete_whenHaveTime.txt
+++ b/src/main/java/toComplete_whenHaveTime.txt
@@ -20,7 +20,6 @@ gradle tools:
 ./gradlew test
 ./gradlew clean shadowJar
 ./gradlew clean build
-./gradlew checkstyleMain checkstyleTest
 
 shortcut:
 - double click on code -> softwrap


### PR DESCRIPTION
A java stream is used to loop through the tasklist to print out each tasks. In addition, each task printed out follows a particular string format.